### PR TITLE
tests: Use the proposed Harness API for testing Charm actions

### DIFF
--- a/tests/unit/test_charm_pytest.py
+++ b/tests/unit/test_charm_pytest.py
@@ -31,7 +31,7 @@ def test_simple(harness):
     out = harness.run_action("simple")
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
 
 
 def test_input_default_value(harness, caplog):
@@ -39,7 +39,7 @@ def test_input_default_value(harness, caplog):
     out = harness.run_action("input")
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
     assert len(caplog.records) == 1
     assert caplog.records[0].levelname == "INFO"
     default_value = harness.charm.meta.actions["input"].parameters["arg"]
@@ -52,7 +52,7 @@ def test_input(harness, caplog):
     out = harness.run_action("input", {"arg": response})
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
     assert len(caplog.records) == 1
     assert caplog.records[0].levelname == "INFO"
     assert caplog.records[0].msg == f"The 'input' action says: {response}"
@@ -63,7 +63,7 @@ def test_multi_input_default_value(harness, caplog):
     out = harness.run_action("multi-input")
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
     defaults = harness.charm.meta.actions["input"].parameters
     assert len(caplog.records) == defaults["arg2"]["default"]
     for record in caplog.records:
@@ -77,7 +77,7 @@ def test_multi_input_arg1(harness, caplog):
     out = harness.run_action("multi-input", params={"arg1": response})
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
     defaults = harness.charm.meta.actions["input"].parameters
     assert len(caplog.records) == defaults["arg2"]["default"]
     for record in caplog.record:
@@ -91,7 +91,7 @@ def test_multi_input_arg2(harness, caplog):
     out = harness.run_action("multi-input", params={"arg2": count})
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
     defaults = harness.charm.meta.actions["input"].parameters
     assert len(caplog.records) == count
     for record in caplog.records:
@@ -106,7 +106,7 @@ def test_multi_input_arg1_and_arg2(harness, caplog):
     out = harness.run_action("multi-input", params={"arg1": response, "arg2": count})
     assert out.results is None
     assert out.logs == []
-    assert not out.failure
+    assert out.success
     assert len(caplog.records) == count
     for record in caplog.records:
         assert record.levelname == "INFO"
@@ -120,7 +120,7 @@ def test_output(harness, monkeypatch):
     out = harness.run_action("output")
     assert out.results == {"fortune": my_fortune}
     assert out.logs == []
-    assert not out.failure
+    assert out.success
 
 
 def test_logger(harness, monkeypatch):
@@ -149,7 +149,7 @@ def test_logger(harness, monkeypatch):
         "I'm counting to 10: 9",
         "I'm counting to 10: 10",
     ]
-    assert not out.failure
+    assert out.success
 
 
 def test_bad(harness):
@@ -157,7 +157,8 @@ def test_bad(harness):
     out = harness.run_action("bad")
     assert out.results is None
     assert out.logs == []
-    assert out.failure == "Sorry, I just couldn't manage it."
+    assert not out.success
+    assert out.failure_message == "Sorry, I just couldn't manage it."
 
 
 def test_combo_fail(harness, monkeypatch):
@@ -165,7 +166,7 @@ def test_combo_fail(harness, monkeypatch):
     out = harness.run_action("combo", {"should-fail": True})
     assert out.results is None
     assert out.logs == []
-    assert out.failure
+    assert not out.success
 
 
 def test_combo(harness, monkeypatch):
@@ -177,4 +178,4 @@ def test_combo(harness, monkeypatch):
     out = harness.run_action("combo")
     assert out.results == {"fortunes-told": 3}
     assert out.logs == expected_fortunes
-    assert not out.failure
+    assert out.success

--- a/tests/unit/test_charm_unittest.py
+++ b/tests/unit/test_charm_unittest.py
@@ -24,17 +24,17 @@ class TestCharm(unittest.TestCase):
     def test_simple(self):
         """Verify that the 'simple' action runs without error."""
         out = self.harness.run_action("simple")
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
 
     def test_input_default_value(self):
         """Verify that the 'input' action runs correctly (no arg is provided)."""
         with self.assertLogs(level="INFO") as cm:
             out = self.harness.run_action("input")
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
         default_value = self.harness.charm.meta.actions["input"].parameters["arg"]
         self.assertEqual(cm.output, [f"INFO:charm:The 'input' action says: {default_value}"])
 
@@ -43,18 +43,18 @@ class TestCharm(unittest.TestCase):
         response = "hello"
         with self.assertLogs(level="INFO") as cm:
             out = self.harness.run_action("input", {"arg": response})
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
         self.assertEqual(cm.output, [f"INFO:charm:The 'input' action says: {response}"])
 
     def test_multi_input_default_value(self):
         """Verify that the 'multi-input' action runs correctly (no arg is provided)."""
         with self.assertLogs(level="INFO") as cm:
             out = self.harness.run_action("multi-input")
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
         defaults = self.harness.charm.meta.actions["input"].parameters
         self.assertEqual(
             cm.output, [f"INFO:charm:The 'multi-input' action says: {defaults['arg1']['default']}"]
@@ -65,9 +65,9 @@ class TestCharm(unittest.TestCase):
         response = "hello"
         with self.assertLogs(level="INFO") as cm:
             out = self.harness.run_action("multi-input", params={"arg1": response})
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
         self.assertEqual(cm.output, [f"INFO:charm:The 'multi-input' action says: {response}"])
 
     def test_multi_input_arg2(self):
@@ -75,9 +75,9 @@ class TestCharm(unittest.TestCase):
         count = 2
         with self.assertLogs(level="INFO") as cm:
             out = self.harness.run_action("multi-input", params={"arg2": count})
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
         defaults = self.harness.charm.meta.actions["input"].parameters
         self.assertEqual(
             cm.output,
@@ -90,9 +90,9 @@ class TestCharm(unittest.TestCase):
         count = 3
         with self.assertLogs(level="INFO") as cm:
             out = self.harness.run_action("multi-input", params={"arg1": response, "arg2": count})
-        assert out.results is None
-        assert out.logs == []
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
         self.assertEqual(
             cm.output, [f"INFO:charm:The 'multi-input' action says: {response}"] * count
         )
@@ -102,49 +102,53 @@ class TestCharm(unittest.TestCase):
         my_fortune = "favours the brave"
         with unittest.mock.patch.object(fortune, "get_random_fortune", return_value=my_fortune):
             out = self.harness.run_action("output")
-        assert out.results == {"fortune": my_fortune}
-        assert out.logs == []
-        assert not out.failure
+        self.assertEqual(out.results, {"fortune": my_fortune})
+        self.assertEqual(out.logs, [])
+        self.assertTrue(out.success)
 
     def test_logger(self):
         """Verify that the 'logger' action runs without error."""
         # Also make this a bit faster :)
         with unittest.mock.patch.object(time, "sleep"):
             out = self.harness.run_action("logger")
-        assert out.results is None
-        assert out.logs == [
-            "I'm counting to 10: 1",
-            "I'm counting to 10: 2",
-            "I'm counting to 10: 3",
-            "I'm counting to 10: 4",
-            "I'm counting to 10: 5",
-            "I'm counting to 10: 6",
-            "I'm counting to 10: 7",
-            "I'm counting to 10: 8",
-            "I'm counting to 10: 9",
-            "I'm counting to 10: 10",
-        ]
-        assert not out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(
+            out.logs,
+            [
+                "I'm counting to 10: 1",
+                "I'm counting to 10: 2",
+                "I'm counting to 10: 3",
+                "I'm counting to 10: 4",
+                "I'm counting to 10: 5",
+                "I'm counting to 10: 6",
+                "I'm counting to 10: 7",
+                "I'm counting to 10: 8",
+                "I'm counting to 10: 9",
+                "I'm counting to 10: 10",
+            ],
+        )
+        self.assertTrue(out.success)
 
     def test_bad(self):
         """Verify that the 'bad' action runs without error (but fails)."""
         out = self.harness.run_action("bad")
-        assert out.results is None
-        assert out.logs == []
-        assert out.failure == "Sorry, I just couldn't manage it."
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertFalse(out.success)
+        self.assertEqual(out.failure, "Sorry, I just couldn't manage it.")
 
     def test_combo_fail(self):
         """Verify that the 'combo' action fails when instructed to do so."""
         out = self.harness.run_action("combo", {"should-fail": True})
-        assert out.results is None
-        assert out.logs == []
-        assert out.failure
+        self.assertIsNone(out.results)
+        self.assertEqual(out.logs, [])
+        self.assertFalse(out.success)
 
     def test_combo(self):
         """Verify that the 'combo' action runs without error."""
         my_fortunes = ["magazine", "500", "cookie"]
         with unittest.mock.patch.object(fortune, "get_random_fortune", side_effect=my_fortunes):
             out = self.harness.run_action("combo")
-        assert out.results == {"fortunes-told": 3}
-        assert out.logs == my_fortunes
-        assert not out.failure
+        self.assertEqual(out.results, {"fortunes-told": 3})
+        self.assertEqual(out.logs, my_fortunes)
+        self.assertTrue(out.success)

--- a/tests/unit/test_charm_unittest.py
+++ b/tests/unit/test_charm_unittest.py
@@ -5,7 +5,6 @@
 
 """Test the charm using Harness with unittest."""
 
-import os
 import time
 import unittest
 import unittest.mock
@@ -22,195 +21,130 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "simple"})
     def test_simple(self):
         """Verify that the 'simple' action runs without error."""
-        with unittest.mock.patch.object(self.harness.charm.framework.model._backend, "action_get"):
-            self.harness.charm.on.simple_action.emit()
+        out = self.harness.run_action("simple")
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "input"})
     def test_input_default_value(self):
         """Verify that the 'input' action runs correctly (no arg is provided)."""
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            unittest.mock.MagicMock(
-                return_value=self.harness.charm.meta.actions["input"].parameters
-            ),
-        ):
-            with self.assertLogs(level="INFO") as cm:
-                self.harness.charm.on.input_action.emit()
+        with self.assertLogs(level="INFO") as cm:
+            out = self.harness.run_action("input")
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
         default_value = self.harness.charm.meta.actions["input"].parameters["arg"]
         self.assertEqual(cm.output, [f"INFO:charm:The 'input' action says: {default_value}"])
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "input"})
     def test_input(self):
         """Verify that the 'input' action runs correctly (an arg is provided)."""
         response = "hello"
-        params = {"arg": response}
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            unittest.mock.MagicMock(return_value=params),
-        ):
-            with self.assertLogs(level="INFO") as cm:
-                self.harness.charm.on.input_action.emit()
+        with self.assertLogs(level="INFO") as cm:
+            out = self.harness.run_action("input", {"arg": response})
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
         self.assertEqual(cm.output, [f"INFO:charm:The 'input' action says: {response}"])
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "multi-input"})
     def test_multi_input_default_value(self):
         """Verify that the 'multi-input' action runs correctly (no arg is provided)."""
-        params = {
-            key: details["default"]
-            for key, details in self.harness.charm.meta.actions["multi-input"].parameters.items()
-        }
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            unittest.mock.MagicMock(return_value=params),
-        ):
-            with self.assertLogs(level="INFO") as cm:
-                self.harness.charm.on.multi_input_action.emit()
+        with self.assertLogs(level="INFO") as cm:
+            out = self.harness.run_action("multi-input")
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
+        defaults = self.harness.charm.meta.actions["input"].parameters
         self.assertEqual(
-            cm.output, [f"INFO:charm:The 'multi-input' action says: {params['arg1']}"]
+            cm.output, [f"INFO:charm:The 'multi-input' action says: {defaults['arg1']['default']}"]
         )
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "multi-input"})
     def test_multi_input_arg1(self):
         """Verify that the 'multi-input' action runs correctly (arg1 is provided)."""
-        params = {
-            key: details["default"]
-            for key, details in self.harness.charm.meta.actions["multi-input"].parameters.items()
-        }
         response = "hello"
-        params["arg1"] = response
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            unittest.mock.MagicMock(return_value=params),
-        ):
-            with self.assertLogs(level="INFO") as cm:
-                self.harness.charm.on.multi_input_action.emit()
+        with self.assertLogs(level="INFO") as cm:
+            out = self.harness.run_action("multi-input", params={"arg1": response})
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
         self.assertEqual(cm.output, [f"INFO:charm:The 'multi-input' action says: {response}"])
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "multi-input"})
     def test_multi_input_arg2(self):
         """Verify that the 'multi-input' action runs correctly (arg2 is provided)."""
-        params = {
-            key: details["default"]
-            for key, details in self.harness.charm.meta.actions["multi-input"].parameters.items()
-        }
         count = 2
-        params["arg2"] = count
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            unittest.mock.MagicMock(return_value=params),
-        ):
-            with self.assertLogs(level="INFO") as cm:
-                self.harness.charm.on.multi_input_action.emit()
+        with self.assertLogs(level="INFO") as cm:
+            out = self.harness.run_action("multi-input", params={"arg2": count})
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
+        defaults = self.harness.charm.meta.actions["input"].parameters
         self.assertEqual(
-            cm.output, [f"INFO:charm:The 'multi-input' action says: {params['arg1']}"] * count
+            cm.output,
+            [f"INFO:charm:The 'multi-input' action says: {defaults['arg1']['default']}"] * count,
         )
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "multi-input"})
     def test_multi_input_arg1_and_arg2(self):
         """Verify that the 'multi-input' action runs correctly (arg1 and arg2 are provided)."""
         response = "hello"
         count = 3
-        params = {"arg1": response, "arg2": count}
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            unittest.mock.MagicMock(return_value=params),
-        ):
-            with self.assertLogs(level="INFO") as cm:
-                self.harness.charm.on.multi_input_action.emit()
+        with self.assertLogs(level="INFO") as cm:
+            out = self.harness.run_action("multi-input", params={"arg1": response, "arg2": count})
+        assert out.results is None
+        assert out.logs == []
+        assert not out.failure
         self.assertEqual(
             cm.output, [f"INFO:charm:The 'multi-input' action says: {response}"] * count
         )
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "output"})
     def test_output(self):
         """Verify that the 'output' action runs correctly."""
         my_fortune = "favours the brave"
-        with unittest.mock.patch.object(self.harness.charm.framework.model._backend, "action_get"):
-            with unittest.mock.patch.object(
-                fortune, "get_random_fortune", return_value=my_fortune
-            ):
-                with unittest.mock.patch.object(
-                    self.harness.charm.framework.model._backend, "action_set"
-                ) as mock_set:
-                    self.harness.charm.on.output_action.emit()
-                    mock_set.assert_called_once_with({"fortune": my_fortune})
+        with unittest.mock.patch.object(fortune, "get_random_fortune", return_value=my_fortune):
+            out = self.harness.run_action("output")
+        assert out.results == {"fortune": my_fortune}
+        assert out.logs == []
+        assert not out.failure
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "logger"})
     def test_logger(self):
         """Verify that the 'simple' action runs without error."""
-        with unittest.mock.patch.object(self.harness.charm.framework.model._backend, "action_get"):
-            with unittest.mock.patch.object(
-                self.harness.charm.framework.model._backend, "action_log"
-            ) as mock_log:
-                # Also make this a bit faster :)
-                with unittest.mock.patch.object(time, "sleep"):
-                    self.harness.charm.on.logger_action.emit()
-                    mock_log.assert_has_calls(
-                        [
-                            unittest.mock.call("I'm counting to 10: 1"),
-                            unittest.mock.call("I'm counting to 10: 2"),
-                            unittest.mock.call("I'm counting to 10: 3"),
-                            unittest.mock.call("I'm counting to 10: 4"),
-                            unittest.mock.call("I'm counting to 10: 5"),
-                            unittest.mock.call("I'm counting to 10: 6"),
-                            unittest.mock.call("I'm counting to 10: 7"),
-                            unittest.mock.call("I'm counting to 10: 8"),
-                            unittest.mock.call("I'm counting to 10: 9"),
-                            unittest.mock.call("I'm counting to 10: 10"),
-                        ]
-                    )
+        # Also make this a bit faster :)
+        with unittest.mock.patch.object(time, "sleep"):
+            out = self.harness.run_action("logger")
+        assert out.results is None
+        assert out.logs == [
+            "I'm counting to 10: 1",
+            "I'm counting to 10: 2",
+            "I'm counting to 10: 3",
+            "I'm counting to 10: 4",
+            "I'm counting to 10: 5",
+            "I'm counting to 10: 6",
+            "I'm counting to 10: 7",
+            "I'm counting to 10: 8",
+            "I'm counting to 10: 9",
+            "I'm counting to 10: 10",
+        ]
+        assert not out.failure
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "bad"})
     def test_bad(self):
         """Verify that the 'bad' action runs without error (but fails)."""
-        with unittest.mock.patch.object(self.harness.charm.framework.model._backend, "action_get"):
-            with unittest.mock.patch.object(
-                self.harness.charm.framework.model._backend, "action_fail"
-            ) as mock_fail:
-                self.harness.charm.on.bad_action.emit()
-                mock_fail.assert_called_once()
+        out = self.harness.run_action("bad")
+        assert out.results is None
+        assert out.logs == []
+        assert out.failure == "Sorry, I just couldn't manage it."
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "combo"})
     def test_combo_fail(self):
         """Verify that the 'combo' action fails when instructed to do so."""
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            return_value={"should-fail": True},
-        ):
-            with unittest.mock.patch.object(
-                self.harness.charm.framework.model._backend, "action_fail"
-            ) as mock_fail:
-                self.harness.charm.on.combo_action.emit()
-                mock_fail.assert_called_once()
+        out = self.harness.run_action("combo", {"should-fail": True})
+        assert out.results is None
+        assert out.logs == []
+        assert out.failure
 
-    @unittest.mock.patch.dict(os.environ, {"JUJU_ACTION_NAME": "combo"})
     def test_combo(self):
         """Verify that the 'combo' action runs without error."""
         my_fortunes = ["magazine", "500", "cookie"]
-        with unittest.mock.patch.object(
-            self.harness.charm.framework.model._backend,
-            "action_get",
-            return_value={"should-fail": False},
-        ):
-            with unittest.mock.patch.object(
-                self.harness.charm.framework.model._backend, "action_log"
-            ) as mock_log:
-                with unittest.mock.patch.object(
-                    fortune, "get_random_fortune", side_effect=my_fortunes
-                ):
-                    with unittest.mock.patch.object(
-                        self.harness.charm.framework.model._backend, "action_set"
-                    ) as mock_set:
-                        self.harness.charm.on.combo_action.emit()
-                        mock_log.assert_has_calls([unittest.mock.call(f) for f in my_fortunes])
-                        mock_set.assert_called_once_with({"fortunes-told": 3})
+        with unittest.mock.patch.object(fortune, "get_random_fortune", side_effect=my_fortunes):
+            out = self.harness.run_action("combo")
+        assert out.results == {"fortunes-told": 3}
+        assert out.logs == my_fortunes
+        assert not out.failure


### PR DESCRIPTION
This converts the exiting unittest and pytest unit tests to use the proposed API for testing actions using `ops.testing.Harness`.